### PR TITLE
Use eval { } safely

### DIFF
--- a/lib/Mail/DKIM/ARC/Signer.pm
+++ b/lib/Mail/DKIM/ARC/Signer.pm
@@ -247,11 +247,16 @@ sub finish_header {
         $header =~ s/[\r\n]+$//;
         if ( $header =~ m/^Authentication-Results:/ ) {
             my ( $arval ) = $header =~ m/^Authentication-Results:[^;]*;\s*(.*)/is;
-            my $parsed = eval{ Mail::AuthenticationResults::Parser->new->parse( $header ) };
-            if ( my $error = $@ ) {
-              warn "Authentication-Results Header parse error: $error\n$header";
-              next HEADER;
-            }
+            my $parsed;
+	    eval {
+		$parsed= Mail::AuthenticationResults::Parser->new
+		    ->parse( $header );
+		1
+	    } || do {
+		my $error = $@;
+		warn "Authentication-Results Header parse error: $error\n$header";
+		next HEADER;
+            };
             my $ardom = $parsed->value->value;
 
             next

--- a/lib/Mail/DKIM/AuthorDomainPolicy.pm
+++ b/lib/Mail/DKIM/AuthorDomainPolicy.pm
@@ -54,9 +54,11 @@ sub fetch {
     my $class = shift;
     my %prms  = @_;
 
-    my $self = eval {
+    my $self;
+    my $had_error= not eval {
         local $SIG{__DIE__};
-        $class->SUPER::fetch(%prms);
+        $self= $class->SUPER::fetch(%prms);
+	1
     };
     my $E = $@;
 
@@ -83,7 +85,7 @@ sub fetch {
         }
     }
 
-    die $E if $E;
+    die $E if $had_error;
     return $self;
 }
 

--- a/lib/Mail/DKIM/PrivateKey.pm
+++ b/lib/Mail/DKIM/PrivateKey.pm
@@ -117,11 +117,11 @@ sub convert {
     eval {
         local $SIG{__DIE__};
         $cork = new_private_key Crypt::OpenSSL::RSA($pkcs);
+	1
+    } || do {
+	$self->errorstr($@);
+	return;
     };
-
-    $@
-      and $self->errorstr($@),
-      return;
 
     $cork
       or return;

--- a/lib/Mail/DKIM/PublicKey.pm
+++ b/lib/Mail/DKIM/PublicKey.pm
@@ -174,8 +174,8 @@ sub check {
     eval {
         local $SIG{__DIE__};
         $self->cork;
-    };
-    if ($@) {
+	1
+    } || do {
 
         # see also finish_body
         chomp( my $E = $@ );
@@ -186,7 +186,7 @@ sub check {
             $E = "OpenSSL $1";
         }
         die "$E\n";
-    }
+    };
 
     # check service type
     if ( my $s = $self->get_tag('s') ) {
@@ -338,11 +338,11 @@ sub verify {
     eval {
         local $SIG{__DIE__};
         $rtrn = $self->cork->verify( $prms{'Text'}, $prms{'Signature'} );
+	1
+    } || do {
+	$self->errorstr($@);
+	return;
     };
-
-    $@
-      and $self->errorstr($@),
-      return;
 
     return $rtrn;
 }

--- a/lib/Mail/DKIM/Verifier.pm
+++ b/lib/Mail/DKIM/Verifier.pm
@@ -154,8 +154,8 @@ sub handle_header {
             local $SIG{__DIE__};
             my $signature = Mail::DKIM::Signature->parse($line);
             $self->add_signature($signature);
-        };
-        if ($@) {
+	    1
+        } || do {
 
             # the only reason an error should be thrown is if the
             # signature really is unparse-able
@@ -164,7 +164,7 @@ sub handle_header {
 
             chomp( my $E = $@ );
             $self->{signature_reject_reason} = $E;
-        }
+        };
     }
 
     if ( lc($field_name) eq 'domainkey-signature' ) {
@@ -172,8 +172,8 @@ sub handle_header {
             local $SIG{__DIE__};
             my $signature = Mail::DKIM::DkSignature->parse($line);
             $self->add_signature($signature);
-        };
-        if ($@) {
+	    1
+        } || do {
 
             # the only reason an error should be thrown is if the
             # signature really is unparse-able
@@ -182,7 +182,7 @@ sub handle_header {
 
             chomp( my $E = $@ );
             $self->{signature_reject_reason} = $E;
-        }
+        };
     }
 }
 
@@ -347,12 +347,12 @@ sub check_public_key {
             $empty_g_means_wildcard );
 
         die $@ if $@;
-    };
-    if ($@) {
+	1
+    } || do {
         my $E = $@;
         chomp $E;
         $self->{signature_reject_reason} = "public key: $E";
-    }
+    };
     return $result;
 }
 
@@ -428,13 +428,13 @@ sub _check_and_verify_signature {
 
     # get public key
     my $pkey;
-    eval { $pkey = $signature->get_public_key; };
-    if ($@) {
+    eval { $pkey = $signature->get_public_key; 1 }
+    || do {
         my $E = $@;
         chomp $E;
         $self->{signature_reject_reason} = "public key: $E";
         return ( 'invalid', $self->{signature_reject_reason} );
-    }
+    };
 
     unless ( $self->check_public_key( $signature, $pkey ) ) {
         return ( 'invalid', $self->{signature_reject_reason} );
@@ -454,8 +454,8 @@ sub _check_and_verify_signature {
     eval {
         $result = $algorithm->verify() ? 'pass' : 'fail';
         $details = $algorithm->{verification_details} || $@;
-    };
-    if ($@) {
+	1
+    } || do {
 
         # see also add_signature
         chomp( my $E = $@ );
@@ -467,7 +467,7 @@ sub _check_and_verify_signature {
         }
         $result  = 'fail';
         $details = $E;
-    }
+    };
     return ( $result, $details );
 }
 


### PR DESCRIPTION
$@ can be clobbered in destructors not using "local" to protect $@,
which is why checking for exceptions via $@ is unsafe. This is
something recognized in the Perl community and something that the
author of this patch has been bitten by in other projects.

(I noticed that some cases of eval were already rewritten that way in
commit 6d397bb1fe3716a1d2b080063a4282d755ad6fc1.)