### PR TITLE
Add missing Author prerequisite

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,9 @@ format = %-9v %{yyyy-MM-dd VVVV}d
 
 [AutoPrereqs]
 
+[Prereqs]
+; authordep Pod::Weaver::Section::Contributors
+
 [PodWeaver]
 ;[%PodWeaver]
 Contributors.contributors[0] = John Levine <john.levine@standcore.com>


### PR DESCRIPTION
`Pod::Weaver::Section::Contributors` is required, otherwise build fails with:
```
Pod::Weaver::Section::Contributors (for section Contributors) does not appear to be installed


Trace begun at /usr/share/perl5/vendor_perl/Config/MVP/Section.pm line 262
Config::MVP::Section::missing_package('Config::MVP::Section=HASH(0x559ab82bcd80)', 'Pod::Weaver::Section::Contributors', 'Contributors') called at /usr/share/perl5/vendor_perl/Config/MVP/Section.pm line 231

```